### PR TITLE
Javamap

### DIFF
--- a/framework/TestSuiteRunner.cfc
+++ b/framework/TestSuiteRunner.cfc
@@ -28,20 +28,23 @@
 		<cfset var methodIndex = 1>
 		<cfset var currentTestSuiteName = "" />
 		<cfset var currentSuite = "" />
-
-		<cfloop collection="#allSuites#" item="currentTestSuiteName">
-			<cfset currentSuite = allSuites[currentTestSuiteName] />
-
+		<cfset var iterator = arguments.allSuites.keySet().iterator() />
+	
+		<cfloop condition="#iterator.hasNext()# eq true">
+			<cfset currentTestSuiteName = iterator.next() />
+			<cfset currentSuite = allSuites.get(currentTestSuiteName) />
+			
+			
 			<cfset testCase = createTestCaseFromComponentOrComponentName(currentSuite.ComponentObject) />
-
+			
 			<!--- set the MockingFramework if one has been set for the TestSuite --->
 			<cfif len(variables.MockingFramework)>
 				<cfset testCase.setMockingFramework(variables.MockingFramework) />
 			</cfif>
-
+			
 			<!--- Invoke prior to tests. Class-level setUp --->
 			<cfset testCase.beforeTests() />
-
+			
 			<cfif len(arguments.testMethod)>
 				<cfset runTestMethod(testCase, testMethod, results, currentTestSuiteName) />
 			<cfelse>
@@ -49,7 +52,7 @@
 					<cfset runTestMethod(testCase, currentSuite.methods[methodIndex], results, currentTestSuiteName) />
 				</cfloop>
 			</cfif>
-
+			
 			<!--- Invoke after tests. Class-level tearDown --->
 			<cfset testCase.afterTests()>
 		</cfloop>

--- a/tests/framework/TestSuiteTest.cfc
+++ b/tests/framework/TestSuiteTest.cfc
@@ -9,7 +9,7 @@
      testSuite.addAll("mxunit.tests.bugs.fixture.test_with_underscore");
      suites = testSuite.suites();
      //debug(suites["mxunit.tests.bugs.fixture.test-with_hyphen"]);
-     methods = suites["mxunit.tests.bugs.fixture.test-with_hyphen"].methods;
+     methods = suites.get("mxunit.tests.bugs.fixture.test-with_hyphen").methods;
      assertEquals(3,arrayLen(methods),"Should be adding to methods element.");
     
     </cfscript>
@@ -53,6 +53,17 @@
 		</cfscript>   
 	</cffunction>
 
+	<cffunction name="testGetMapReturnsMap">
+		<cfscript>
+		var testSuite = createObject("component","mxunit.framework.TestSuite").TestSuite();   
+		var map = "";
+
+		makePublic(testSuite,"getMap");
+		map = testSuite.getMap();
+		
+		assertTrue(isInstanceof(map,"java.util.Map"));
+		</cfscript>
+	</cffunction>
 
 	<cffunction name="setUp" access="public" returntype="void">
 


### PR DESCRIPTION
These changes will allow tests added to a testsuite to run in the order they are added.  It replaces the testSuites struct datatype with a Java LinkedHashMap (http://download.oracle.com/javase/6/docs/api/java/util/LinkedHashMap.html), the API is slightly different than the a struct so I updated the supporting code in TestSuite.cfc and TestSuiteRunner.cfc and tests as well.   

I'm not sure how I have the commits from Bob and Bill in this pull though, my local repository is current with the develop branch.  Any ideas how that happened?  If I need to update this request to only get my changes let me know.  

-Ryan
