### PR TITLE
Enable mxunit_root to be overridden. This allows user to set the css/sty...

### DIFF
--- a/framework/TestResult.cfc
+++ b/framework/TestResult.cfc
@@ -233,6 +233,7 @@
 	--->
 	<cffunction name="getResultsOutput" returntype="any" hint="" access="public" output="false">
 		<cfargument name="mode" required="true" default="" />
+                <cfargument name="mxunit_root" required="false" default=""/>
 
 		<cfset arguments.mode = listLast(arguments.mode) />
 
@@ -266,7 +267,11 @@
 			</cfcase>
 
 			<cfdefaultcase>
-				<cfreturn getHTMLResults() />
+				<cfif len(argumenst.mxunit_root>
+					<cfreturn getHTMLResults(arguments.mxunit_root) />
+				<cfelse>
+					<cfreturn getHTMLResults() />
+				</cfif>					
 			</cfdefaultcase>
 		</cfswitch>
 	</cffunction>


### PR DESCRIPTION
...les location.

Example:
<cfoutput>#results.getResultsOutput(URL.output,'railo-ajax/mxunit')#</cfoutput>

This can help a lot testing with war deployment under differents contexts.
