### PR TITLE
Allow spaces when specifying multiple decorators

### DIFF
--- a/framework/TestCase.cfc
+++ b/framework/TestCase.cfc
@@ -528,7 +528,7 @@
 		<cfset decoratorNames = listPrepend( decoratorNames, getRequiredDecoratorPaths() ) />
 
 		<cfloop list="#decoratorNames#" index="decoratorPath">
-			<cfset decorator = createObject("component", decoratorPath)/>
+			<cfset decorator = createObject("component", trim(decoratorPath)/>
 			<cfset decorator.setTarget(object)/>
 			<cfset decorator.metadata = meta />
 			<cfset arguments.object = decorator/> <!--- flip it and reverse it. --->

--- a/tests/framework/TestDecoratorTest.cfc
+++ b/tests/framework/TestDecoratorTest.cfc
@@ -1,5 +1,5 @@
 <cfcomponent extends="mxunit.framework.TestCase" output="false"
-	mxunit:decorators="mxunit.tests.framework.fixture.decorators.StoreTestNameDecorator,mxunit.tests.framework.fixture.decorators.IgnoreFunnyFunctionsDecorator">
+	mxunit:decorators="mxunit.tests.framework.fixture.decorators.StoreTestNameDecorator, mxunit.tests.framework.fixture.decorators.IgnoreFunnyFunctionsDecorator">
 
 	<cffunction name="testDecoratorWrappingTest" hint="test to see if the decorator gets called and places the name of the test in the request scope"
 				access="public" returntype="void" output="false">


### PR DESCRIPTION
When specifying multiple decorators adding a space after the comma causes the framework to crash because it cannot locate the decorator.  I've updated TestDecoratorTest to reflect the condition.  

Example: 

``` cfm
<component extends="mxunit.framework.TestCase" output="false"
    mxunit:decorators="...StoreTestNameDecorator, ...IgnoreFunnyFunctionsDecorator">
```

This would fail because it couldn't find &lt;space&gt;IgnoreFunnyFunctionsDecorator

It looks like some line endings may have had windows delims in TestCase.cfc, however the actual update I did is on line 531.
