### PR TITLE
Verifier methods case sensitivity

### DIFF
--- a/framework/mightymock/MightyMock.cfc
+++ b/framework/mightymock/MightyMock.cfc
@@ -159,7 +159,14 @@
    var tempMock = chr(0);
    var temp = '';
 
-   missingMethodArguments = createObject('java','java.util.TreeMap').init(missingMethodArguments);
+   /*
+    * Ensure we maintain key order using a TreeMap. Furthermore
+    * make sure we are doing case insensitive key comparisons.
+    */
+   var map = createObject("java", "java.util.TreeMap").init(createObject("java", "java.lang.String").CASE_INSENSITIVE_ORDER);
+   map.putAll(missingMethodArguments);
+
+   missingMethodArguments = map;
 
    if( currentState == 'verifying'){
       verifier.doVerify(tempRule[1], missingMethodName, missingMethodArguments, tempRule[2], registry );


### PR DESCRIPTION
When a call to a **verify()** method using named parameters does not have the same case as the keys in the method mock definition the verify would fail. For example, consider the following code:

``` coldfusion
    <cffunction name="updateEmployee_CallsDAOOnce" access="public" output="true">
        <cfscript>
            var employeeDAOMock = mock();
            employeeDAOMock.updateEmployee(
                firstName="{string}", 
                lastName="{string}", 
                age="{any}",
                height="{any}"
            );

            injectProperty(variables.employeeService, "employeeDAO", employeeDAOMock);

            variables.employeeService.updateEmployee(
                firstName="Bob", 
                lastName="Hope", 
                age=125,
                height=6.7
            );

            variables.employeeService.employeeDAO.verifyOnce().updateEmployee(
                firstName="{string}", 
                LASTNAME="{string}", 
                age="{any}",
                HEIght="{any}"
            );

        </cfscript>
    </cffunction>
```

Notice the keys in the mock definition do not match the case of the keys in the verify() call. By default the TreeMap comparator is case sensitive. I changed the code to instantiate the TreeMap using a case insensitive comparator and THEN add all the missing method args. This was tested and verified in ColdFusion 9.
