### PR TITLE
Can we make DirectoryTestSuite.getTests() public?

### DIFF
--- a/runner/DirectoryTestSuite.cfc
+++ b/runner/DirectoryTestSuite.cfc
@@ -41,7 +41,7 @@
 		<cfreturn testResult>
 	</cffunction>
 
-	<cffunction name="getTests" access="private" output="false">
+	<cffunction name="getTests" access="public" output="false">
 		<cfargument name="directory" required="true" hint="directory of tests to run">
 		<cfargument name="componentPath" required="true" hint="the component path to put in front of all tests found (i.e. 'com.blah')">
 		<cfargument name="recurse" required="false" default="true" type="boolean" hint="whether to recurse down the directory tree">


### PR DESCRIPTION
So I [made this thing](https://github.com/atuttle/mxunit-watch#mxunit-watch) that I think is pretty cool:

![](https://f.cloud.github.com/assets/46990/1242419/fe2a6fd2-2a3f-11e3-85c0-432200d85c67.png)

Only problem is that to make it I had to modify my MXUnit install and make 1 tiny change -- the one included in this pull request.

It simply makes the `getTests` method of the `mxunit.runner.DirectoryTestSuite` class public instead of private. This is done so that I can [get a list of the test suites and their associated tests in a very machine-usable format](https://github.com/atuttle/mxunit-watch#add-a-cfm-file-to-your-project).

I can't think of any harm that could come from changing the access level of this method; other than it would become part of the officially supported API of the framework and that might come with some maintenance concerns?

If you accept this pull request, then I can remove the pre-requisite of modifying your mxunit install in order to use mxunit-watcher. What do you say? :)
