### PR TITLE
Make JUnit XML results show exception message not just type.

### DIFF
--- a/framework/JUnitXMLTestResult.cfc
+++ b/framework/JUnitXMLTestResult.cfc
@@ -108,7 +108,7 @@
 				if( listFindNoCase("Failed",testResults.testStatus)){
 					this.resultsXML = this.resultsXML & '<failure message="#xmlformat(testResults.error.message)#"><![CDATA[#generateStacktrace(testResults.error)#]]></failure>';
 				} else if( listFindNoCase("Error",testResults.testStatus)) {
-					this.resultsXML = this.resultsXML & '<error message="#testResults.error.type#"><![CDATA[#generateStacktrace(testResults.error)#]]></error>';
+					this.resultsXML = this.resultsXML & '<error message="#testResults.error.type#: #xmlFormat(testResults.error.message)#"><![CDATA[#generateStacktrace(testResults.error)#]]></error>';
 				}
 
 				this.resultsXML = this.resultsXML & '</testcase>';


### PR DESCRIPTION
Make JUnit XML results match regular xml results by showing the exception message, not just the type ( see line 83 of XMLTestResult.cfc for the code that shows the message in XML and is not included in JUnit xml )
