### PR TITLE
Cleanup addTest()

### DIFF
--- a/framework/TestSuite.cfc
+++ b/framework/TestSuite.cfc
@@ -28,7 +28,6 @@
 		<cfargument name="componentObject" type="Any" required="no" default="" />
 
 		<cfscript>
-			var newStruct = {};
 			try{
 				this.tempStruct = structNew();
 				this.tempStruct.ComponentObject = arguments.ComponentObject;
@@ -46,14 +45,10 @@
 					this.testSuites.put(arguments.componentName, this.tempStruct);
 				} else{
 					//Begin a new test Suite
-					this.testSuite.put(arguments.componentName, this.tempStruct);
+					//TODO: Grab all the methods that begin with the string 'test' ...
+					this.tempStruct.methods = listToArray(arguments.method);
 
-					//Grab all the methods that begin with the string 'test' ...
-					tests = listToArray(arguments.method);
-
-					newStruct.methods = tests;
-
-					this.testSuites.put(arguments.componentName,newStruct);
+					this.testSuites.put(arguments.componentName,this.tempStruct);
 				}
 			} catch (Exception e) {
 				writeoutput(e.getMessage());


### PR DESCRIPTION
I saw the same misspelling that stephen-condon caught, but also noticed that the else part of this function was mess.
- Fixed "this.testSuite", supposed to be "this.testSuites"
- newStruct and tests are extra variables that aren't needed
- Using this.tempStruct so the ComponentObject is actually set. It wasn't being set on newStruct.
- Added a TODO tag to the comment about missing functionality.
