### PR TITLE
Add a cfcontent tag to printResources() in mxunit.framework.HtmlTestResu...

### DIFF
--- a/framework/HtmlTestResult.cfc
+++ b/framework/HtmlTestResult.cfc
@@ -48,6 +48,7 @@
 	<cffunction name="printResources" access="public" output="true" hint="Prints CSS and JavaScript refs for stylizing">
  		<cfargument name="mxunit_root" required="no" default="./mxunit" hint="Location in the webroot where MXUnit is installed." />
 		<cfargument name="test_title" required="false" default="MXUnit Test Results" offhint="An HTML title to display for this test" />
+			<cfcontent type="text/html">
 			<link rel="stylesheet" type="text/css" href="#mxunit_root#/resources/theme/styles.css">
 			<link rel="stylesheet" type="text/css" href="#mxunit_root#/resources/jquery/tablesorter/green/style.css">
 			<link rel="stylesheet" type="text/css" href="#mxunit_root#/resources/theme/results.css">
@@ -123,7 +124,7 @@
 							</li>
 						</ul>
 
-						<!-- brain no working, but this does --->
+						<!--- brain no working, but this does --->
 						<cfif find('debug=true',cgi.QUERY_STRING)>
 							<cfset toggledUrl = cgi.SCRIPT_NAME & '?' & replace(cgi.QUERY_STRING,'debug=true','debug=false') />
 							<cfset bugMessage = 'Run without debug output.' />


### PR DESCRIPTION
...lt so Apache doesn't get confused. Also, fixed a malformed comment on line 126 of mxunit.framework.HtmlTestResult.

The browser was getting a cryptic error about invalid XML entities and invalid comments before this change when using ?method=runTestRemote at the end of my test URL. 