### PR TITLE
fixed: stylesheets and js not rendered

### DIFF
--- a/framework/HtmlTestResult.cfc
+++ b/framework/HtmlTestResult.cfc
@@ -72,8 +72,10 @@
 		<cfset var temp = "" />
 
 		<cfsavecontent variable="result">
+			<cfoutput>
 			<cfset printResources(mxunit_root,test_title) />
-			<cfoutput>#trim(getRawHtmlResults(mxunit_root))#</cfoutput>
+			#trim(getRawHtmlResults(mxunit_root))#
+			</cfoutput>
 		</cfsavecontent>
 
 		<cfreturn result>


### PR DESCRIPTION
Moved up <cfoutput> tag to include printResources() call, that otherwise won't show in HTML output.
