### PR TITLE
Adding check for codePrintHTML, allows to run without modifications on OpenBD

### DIFF
--- a/framework/HtmlTestResult.cfc
+++ b/framework/HtmlTestResult.cfc
@@ -247,7 +247,7 @@
 							<cfset line = arguments.ErrorCollection.TagContext[i].line />
 							<tr>
 								<td>
-									<cfif i eq 1>#arguments.ErrorCollection.TagContext[i].codePrintHTML#<br /><br /></cfif>
+									<cfif structKeyExists(arguments.ErrorCollection.TagContext[i], "codePrintHTML") AND i eq 1>#arguments.ErrorCollection.TagContext[i].codePrintHTML#<br /><br /></cfif>
 									#template# (#line#:
 									<a href="txmt://open/?url=file://#template#&line=#line#" title="Open this in TextMate">TM</a>
 									<a href="javascript:void(0)" onclick="$('##cfeclipsecall').load('/cfeclipsecall.cfm?cfe=#replace(template,"\","/","all")#|#line#')" title="Open this in CFEclipe">CFE</a>)


### PR DESCRIPTION
With the check you don't have to make any modifications to run MXUnit on OpenBD.