### PR TITLE
Update generate.cfm

### DIFF
--- a/generator/generate.cfm
+++ b/generator/generate.cfm
@@ -43,7 +43,7 @@
 								class = replaceNoCase( class , "/" , "." , "all" );
 								
 								// invoke it so we can read metadata
-								obj = createObject( "component" , class ); // note that we don't invoke any methods
+								obj = createObject( "component" , "mxunit." & class ); // note that we don't invoke any methods
 								md = getMetaData( obj );
 								md.path = replace(md.path,"\","/","All");								
 							</cfscript>					


### PR DESCRIPTION
test generator failed to find CFC. It would probably be better to dynamically retrieve the directory above generator.cfm in case they change the "mxunit" default foldername, but I need to just get this up and running.